### PR TITLE
`value` can be optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ export type ServerVarAddKey =
               | (string | number | object)[];
       };
 
-export function add(key: ServerVarAddKey, value: any): void;
+export function add(key: ServerVarAddKey, value?: any): void;
 export function get(key: string): any;
 export function inject(): string;
 export function middleware(


### PR DESCRIPTION
the `add` method can accept an object for the first parameter and in turn, it uses `Object.assign` to merge the object into the store