### PR TITLE
removed console.log to minimize server output

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,7 +24,6 @@ const serverVarsFactory = function () {
             return get(this.store, key);
         },
         inject: function () {
-            console.log(this.store);
             var stringified =
                 '<script>window.__SERVER_VARS__ = ' +
                 // safely embed JSON within HTML


### PR DESCRIPTION
I just noticed that server-vars was outputting to the console when run locally. I'm not sure if this is outputting after deployments or not though